### PR TITLE
Src Path/Use template to copy modules.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The role variables and default values.
 ::
 
 	freeswitch_version: v1.4 #FreeSwitch version. Becareful, only tested with 1.4 version for the time being
-	freeswitch_sources_path: /usr/src/freeswitch/ #Path to the FreeSwitch source directory
+	freeswitch_sources_path: /usr/src/freeswitch #Path to the FreeSwitch source directory
 	freeswitch_path: /usr/local/freeswitch/ #Path to the FreeSwith directory
 	freeswitch_owner: freeswitch
 	freeswitch_group: daemon

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 freeswitch_version: v1.4 #FreeSwitch version. Becareful, only tested with 1.4 version for the time being
-freeswitch_sources_path: /usr/src/freeswitch/ #Path to the FreeSwitch source directory
+freeswitch_sources_path: /usr/src/freeswitch #Path to the FreeSwitch source directory
 freeswitch_path: /usr/local/freeswitch/ #Path to the FreeSwith directory
 freeswitch_owner: freeswitch
 freeswitch_group: daemon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
   shell: ./bootstrap.sh -j chdir={{freeswitch_sources_path}}
 
 - name: copy template modules file
-  copy: src={{freeswitch_modules_template}} dest=/usr/src/freeswitch/modules.conf backup=yes
+  template: src={{ freeswitch_modules_template }} dest={{ freeswitch_sources_path }}/modules.conf force=yes
 
 - name: Freeswitch configuration
   shell: ./{{freeswitch_configure_command}} chdir={{freeswitch_sources_path}}


### PR DESCRIPTION
Removed the trailing slash from the src path, and switched from copy to template for `modules.conf`
